### PR TITLE
Add Discord integration for internal notifications

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -32,4 +32,4 @@ jobs:
       env:
         DB_CONNECTION: sqlite
         DB_DATABASE: database/database.sqlite
-      run: vendor/bin/phpunit
+      run: php artisan test

--- a/app/Events/ListingCreated.php
+++ b/app/Events/ListingCreated.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ListingCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Http/Controllers/DiscordController.php
+++ b/app/Http/Controllers/DiscordController.php
@@ -8,8 +8,10 @@ use Illuminate\Http\Request;
 
 class DiscordController extends Controller
 {
-    public function ping()
+    public function ping(Request $request)
     {
+        abort_unless($request->user()->hasRole('admin'), 403);
+
         return (new DiscordEvent)->notify(new DiscordNotification('beep'));
     }
 }

--- a/app/Http/Controllers/DiscordController.php
+++ b/app/Http/Controllers/DiscordController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\DiscordEvent;
+use App\Notifications\DiscordNotification;
+use Illuminate\Http\Request;
+
+class DiscordController extends Controller
+{
+    public function ping()
+    {
+        return (new DiscordEvent)->notify(new DiscordNotification('beep'));
+    }
+}

--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Events\ListingCreated;
 use Illuminate\Support\Facades\App;
 use App\Http\Requests\StoreListingRequest;
 use App\Http\Requests\UpdateListingRequest;
@@ -80,6 +81,7 @@ class ListingController extends Controller
             $listing->save();
         }
 
+        ListingCreated::dispatch($listing);
         UpdateListingsGeospatialIndexEntry::dispatch($listing);
         return Redirect::to(route('listings.show', $listing));
     }

--- a/app/Listeners/Discord/DiscordNotificationListener.php
+++ b/app/Listeners/Discord/DiscordNotificationListener.php
@@ -29,6 +29,10 @@ abstract class DiscordNotificationListener
      */
     public function handle()
     {
+        if (! DiscordEvent::canSendNotification()) {
+            return;
+        }
+        
         return (new DiscordEvent())->notify(new DiscordNotification($this->message));
     }
 }

--- a/app/Listeners/Discord/DiscordNotificationListener.php
+++ b/app/Listeners/Discord/DiscordNotificationListener.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Listeners\Discord;
+
+use App\Models\DiscordEvent;
+use App\Notifications\DiscordNotification;
+
+abstract class DiscordNotificationListener
+{
+    /**
+     * @var string The Discord message to send.
+     */
+    protected string $message;
+
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        return (new DiscordEvent())->notify(new DiscordNotification($this->message));
+    }
+}

--- a/app/Listeners/Discord/SendNewListingCreatedMessage.php
+++ b/app/Listeners/Discord/SendNewListingCreatedMessage.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Listeners\Discord;
+
+class SendNewListingCreatedMessage extends DiscordNotificationListener
+{
+    protected string $message = 'listing.created';
+}

--- a/app/Listeners/Discord/SendUserRegisteredMessage.php
+++ b/app/Listeners/Discord/SendUserRegisteredMessage.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Listeners\Discord;
+
+class SendUserRegisteredMessage extends DiscordNotificationListener
+{
+    protected string $message = 'user.registered';
+}

--- a/app/Models/DiscordEvent.php
+++ b/app/Models/DiscordEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Notifiable;
+
+class DiscordEvent extends Model
+{
+    use Notifiable;
+
+    public function routeNotificationForDiscord()
+    {
+        return config('services.discord.route');
+    }
+}

--- a/app/Models/DiscordEvent.php
+++ b/app/Models/DiscordEvent.php
@@ -13,4 +13,11 @@ class DiscordEvent extends Model
     {
         return config('services.discord.route');
     }
+
+    public static function canSendNotification()
+    {
+        return config('services.discord.token') != ''
+                && config('services.discord.route') != ''
+                && app()->environment() !== 'testing';
+    }
 }

--- a/app/Notifications/DiscordNotification.php
+++ b/app/Notifications/DiscordNotification.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use NotificationChannels\Discord\DiscordChannel;
+use NotificationChannels\Discord\DiscordMessage;
+
+class DiscordNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * The Discord message to send.
+     */
+    protected string $message;
+
+    /**
+     * Create a new notification instance.
+     * 
+     * @param string $message The Discord message to send.
+     *                        Should be a language key defined in the lang file.
+     *                        @see lang/en/discord-messages.php
+     * @param bool $withoutLangKey If true, the message will be sent without the lang key.
+     *                             While discouraged, it allows for on-demand messages.
+     * @return void
+     */
+    public function __construct(string $message, bool $withoutLangKey = false)
+    {
+        $this->message = $withoutLangKey ? $message : __('discord-messages.' . $message);
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return [DiscordChannel::class];
+    }
+
+    public function toDiscord($notifiable)
+    {
+        return DiscordMessage::create($this->message);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,10 +2,13 @@
 
 namespace App\Providers;
 
+use App\Events\ListingCreated;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Event;
+use App\Listeners\Discord\SendUserRegisteredMessage;
+use App\Listeners\Discord\SendNewListingCreatedMessage;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -17,6 +20,10 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+            SendUserRegisteredMessage::class,
+        ],
+        ListingCreated::class => [
+            SendNewListingCreatedMessage::class,
         ],
     ];
 

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "php": "^8.0.2",
         "guzzlehttp/guzzle": "^7.2",
         "kolirt/laravel-openstreetmap": "^1.0",
+        "laravel-notification-channels/discord": "^1.3",
         "laravel/framework": "^9.2",
         "laravel/jetstream": "^2.6",
         "laravel/sanctum": "^2.14.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4e760a2e5c934765c13f0655b3e5781",
+    "content-hash": "1910de02055ca97f5b6aa4e75b5cea45",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1186,6 +1186,74 @@
                 "source": "https://github.com/kolirt/laravel-openstreetmap/tree/v1.0.3"
             },
             "time": "2020-12-21T12:27:03+00:00"
+        },
+        {
+            "name": "laravel-notification-channels/discord",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel-notification-channels/discord.git",
+                "reference": "e6526cd0903b51abe39d3a80b6b1f60c391598e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel-notification-channels/discord/zipball/e6526cd0903b51abe39d3a80b6b1f60c391598e1",
+                "reference": "e6526cd0903b51abe39d3a80b6b1f60c391598e1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.3 || ^7.0",
+                "illuminate/console": "^6.0 || ^7.0 || ^8.0 || ^9.0",
+                "illuminate/notifications": "^6.0 || ^7.0 || ^8.0 || ^9.0",
+                "illuminate/queue": "^6.0 || ^7.0 || ^8.0 || ^9.0",
+                "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0",
+                "php": "^7.2|^8.0",
+                "textalk/websocket": "^1.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench": "^5.0 || ^6.0 || ^7.0",
+                "phpunit/phpunit": "^8.5 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "NotificationChannels\\Discord\\DiscordServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "NotificationChannels\\Discord\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cody Scott",
+                    "email": "cs475x@icloud.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel notification driver for Discord.",
+            "homepage": "https://github.com/laravel-notification-channels/discord",
+            "keywords": [
+                "channel",
+                "discord",
+                "driver",
+                "laravel",
+                "notification"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel-notification-channels/discord/issues",
+                "source": "https://github.com/laravel-notification-channels/discord/tree/v1.3.0"
+            },
+            "time": "2022-02-13T23:55:52+00:00"
         },
         {
             "name": "laravel/fortify",
@@ -5688,6 +5756,55 @@
                 }
             ],
             "time": "2022-03-02T12:58:14+00:00"
+        },
+        {
+            "name": "textalk/websocket",
+            "version": "1.5.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Textalk/websocket-php.git",
+                "reference": "1712325e99b6bf869ccbf9bf41ab749e7328ea46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Textalk/websocket-php/zipball/1712325e99b6bf869ccbf9bf41ab749e7328ea46",
+                "reference": "1712325e99b6bf869ccbf9bf41ab749e7328ea46",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 | ^8.0",
+                "psr/log": "^1 | ^2 | ^3"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^8.0|^9.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WebSocket\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Fredrik Liljegren"
+                },
+                {
+                    "name": "Sören Jensen",
+                    "email": "soren@abicart.se"
+                }
+            ],
+            "description": "WebSocket client and server",
+            "support": {
+                "issues": "https://github.com/Textalk/websocket-php/issues",
+                "source": "https://github.com/Textalk/websocket-php/tree/1.5.7"
+            },
+            "time": "2022-03-29T09:46:59+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",

--- a/config/services.php
+++ b/config/services.php
@@ -34,8 +34,8 @@ return [
 
     'discord' => [
         // The Bot API Token
-        'token' => env('DISCORD_TOKEN'),
+        'token' => env('DISCORD_TOKEN', ''),
         // The Discord Channel ID
-        'route' => env('DISCORD_ROUTE'),
+        'route' => env('DISCORD_ROUTE', ''),
     ],
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -32,4 +32,10 @@ return [
 
     'github_webhook_secret' => env('GITHUB_WEBHOOK_ENDPOINT_SECRET'),
 
+    'discord' => [
+        // The Bot API Token
+        'token' => env('DISCORD_TOKEN'),
+        // The Discord Channel ID
+        'route' => env('DISCORD_ROUTE'),
+    ],
 ];

--- a/resources/lang/en/discord-messages.php
+++ b/resources/lang/en/discord-messages.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Discord Messages
+    |--------------------------------------------------------------------------
+    |
+    | These are the messages that are sent to Discord for various events.
+    |
+    */
+
+    'beep' => 'Beep Boop I\'m a bot! 🤖',
+
+    'user.registered' => ':tada: A new user has signed up!',
+
+    'listing.created' => ':memo: A new listing has been created!',
+];

--- a/resources/markdown/content/welcome/header.md
+++ b/resources/markdown/content/welcome/header.md
@@ -1,4 +1,4 @@
-## Welcome to The United States Mutual Aid App!
+# Welcome to The United States Mutual Aid App!
 
 This mutual aid app is designed for people living in the United States to offer or access freely available resources. We want to enable people in need to easily find resources that they require to get them through difficult times. We also want to enable those willing to volunteer their time or resources to be able to offer them seamlessly and individually without being part of an organization.
 

--- a/resources/views/vendor/jetstream/components/welcome.blade.php
+++ b/resources/views/vendor/jetstream/components/welcome.blade.php
@@ -1,8 +1,4 @@
 <div class="p-6 sm:px-20 bg-white border-b border-gray-200">
-    <div>
-        <x-jet-application-logo class="block h-12 w-auto" />
-    </div>
-
     <div class="mt-8">
         @markdownSection("welcome/header", 'max-w-none')
     </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Http\Controllers\DiscordController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\GitHubWebhookController;
@@ -21,5 +20,3 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::post('/webhooks/github/fetch', GitHubWebhookController::class);
-
-Route::get('/discord/ping', [DiscordController::class, 'ping']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\DiscordController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\GitHubWebhookController;
@@ -20,3 +21,5 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::post('/webhooks/github/fetch', GitHubWebhookController::class);
+
+Route::get('/discord/ping', [DiscordController::class, 'ping']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,3 +32,5 @@ Route::middleware(['auth:sanctum', 'verified', 'can:accessDashboard'])->get('/da
 
 
 Route::get('notices.txt', NoticeController::class);
+
+Route::get('/api/discord/ping', [App\Http\Controllers\DiscordController::class, 'ping'])->middleware('auth:sanctum');


### PR DESCRIPTION
Adds an integration with Discord to send us notification for app events. The notifications are privacy centric and do not include any personal information, and look like this:

![image](https://user-images.githubusercontent.com/95144705/163386018-a0f577ab-d30b-4439-90f5-535b35220195.png)
