### PR TITLE
Patch bug where map page returns 404 if a removed listing is present in the geospatial index

### DIFF
--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -35,7 +35,10 @@ class MapController extends Controller
                 // If the coordinates are invalid we do not add them to the array.
                 continue;
             }
-            $listing = Listing::findOrFail($index->model_id);
+            $listing = Listing::find($index->model_id);
+            if (!$listing) {
+                continue;
+            }
             $markers[] = [
                 'lat' => $index->latitude,
                 'lon' => $index->longitude,


### PR DESCRIPTION
Tested and already hot-patched into QX1 Origin, tagging release for immediate rollout.